### PR TITLE
build: Add CMake submodule auto-update mechanism

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@ endif()
 
 file(GLOB SOURCES ${PROJECT_SOURCE_DIR}/src/*.cpp)
 
+include(cmake/UpdateSubmodules.cmake) # update the submodules here
+
 set(BOOST_INCLUDE_LIBRARIES asio)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/libs/boost EXCLUDE_FROM_ALL)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/libs/wxWidgets)

--- a/cmake/UpdateSubmodules.cmake
+++ b/cmake/UpdateSubmodules.cmake
@@ -1,0 +1,24 @@
+find_package(Git QUIET)
+if(GIT_FOUND)
+    option(UPDATE_SUBMODULES "Check submodules during build" ON)
+    if(NOT UPDATE_SUBMODULES)
+        return()
+    endif()
+
+    execute_process(COMMAND ${GIT_EXECUTABLE} submodule
+                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                    OUTPUT_VARIABLE EXISTING_SUBMODULES
+                    RESULT_VARIABLE RETURN_CODE
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
+    message(STATUS "Updating git submodules:\n${EXISTING_SUBMODULES}")
+
+    execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive
+                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                    RESULT_VARIABLE RETURN_CODE)
+    if(NOT RETURN_CODE EQUAL "0")
+        message(WARNING "Cannot update submodules. Git command failed with ${RETURN_CODE}")
+        return()
+    endif()
+    
+    message(STATUS "Git submodules updated successfully")
+endif()


### PR DESCRIPTION
## Summary  
Automates git submodule initialization during CMake build process for wxWidgets/Boost dependencies.  

## Changes  
- Added `cmake/UpdateSubmodules.cmake` to handle submodule updates  
- Integrated it into root `CMakeLists.txt` via `include(cmake/UpdateSubmodules.cmake)`  

## Impact  
- **No manual steps**: Submodules (wxWidgets/Boost) now initialize automatically during build.  
- **Consistent dependencies**: Ensures correct versions are always used.